### PR TITLE
Simplify examples and add rust playground links for module 1_1

### DIFF
--- a/curriculum/module_1/1_variables.md
+++ b/curriculum/module_1/1_variables.md
@@ -24,35 +24,58 @@ There are several other reasons as well but this is the most important one.
 
 *Examples for readability*
 
-```rust
-fn f(x: i32) -> i32 {
-    // By looking at the function signature we know that the variable x is not
-    // changed within the function
-    return x + 1;
-}
+Below are some examples that you can experiment with yourself on [Rust Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=9a549f8738d6c49c4f6a204b6094cec5):
 
-fn mut_f(mut x: i32) -> i32 {
-    // Now we know that variable x is "potentially" changed within this function
-    // Rust compiler will generate a warning stating that x need not be mutable if
-    // it was declared mutable but not being mutated.
-    x += 1;
-    return x;
+```rust
+#[allow(unused_assignments)]
+fn main() -> () {
+    let num = 2;
+    num = 3; // compiler won't allow this
+    println!("{}", num); // num is not changed
 }
 ```
 
-These problems are profound when working with shared objects/variables as shown in the example
-below,
+```rust
+#[allow(unused_assignments)]
+fn main() -> () {
+    let mut num = 2;
+    num = 3; 
+    println!("{}", num); // num is changed
+}
+```
+
+These problems are profound when working with shared objects/variables as shown in the example below.
+Feel free to experiment with this on [Rust Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=cf7212ce7d3f4d146107f38cb8aca4c3)
 
 ```rust
+#[derive(Debug)]
 struct Point {
     x: i32,
     y: i32,
 }
+
 fn mut_shared_point(p: &mut Point) {
     p.x += 50;
+    p.y += 10;
+}
+
+fn main() -> () {
+    let mut point = Point {
+        x: 10,
+        y: 10,
+    };
+    
+    mut_shared_point(&mut point); // pass in a mutable reference to a point
+    
+    println!("{:?}", point);
 }
 ```
 
-In the above example the caller of the `mut_shared_point` function should be aware that the
-point whose reference is being passed to might change, so this affects how the programmer thinks
-about the lines of code which comes after that function call.
+In the above example the caller of the `mut_shared_point` function should be aware that the point whose reference is being passed to might change, so this affects how the programmer thinks about the lines of code which comes after that function call.
+
+We haven't talked about what a *mutable reference* is exactly (as indicated by `&mut`), but for now it simply means that we're allowed to modify the `Point` struct instance that is passed into the `mut_shared_point` function as an argument.
+
+If the point is not declared as mutable, compilation will fail. 
+If the point is not passed in as a *mutable reference*, compilation will fail as well.
+
+Play around on Rust Playground to get a better feel for this and see what happens when certain variables or arguments are not declared as mutable.


### PR DESCRIPTION
I think the two examples for mutability are not very clear. This could be confusing because of the nature of copy and how the arguments are not actually changing even if the function is called `mut_f`. 

Instead, I would simplify to showcase how the compiler will complain and then add some Rust Playground links as well so that the student can experiment with this themselves.

Also, I see that we start showing `&mut` and this is an advanced concept so I wanted to mention this and explain that we'll dive deeper into it later. 

Let me know what you think.